### PR TITLE
harden order API request handling

### DIFF
--- a/internal/order/transport/http/handler.go
+++ b/internal/order/transport/http/handler.go
@@ -3,18 +3,23 @@ package http
 import (
 	"context"
 	"encoding/json"
-	"github.com/GolangDeveloperAlmir/order-service/internal/order/domain"
-	ordersvc "github.com/GolangDeveloperAlmir/order-service/internal/order/service"
-	"github.com/GolangDeveloperAlmir/order-service/internal/platform/idempotency"
-	"github.com/GolangDeveloperAlmir/order-service/internal/platform/saga"
-	"github.com/GolangDeveloperAlmir/order-service/pkg/respond"
-	"github.com/google/uuid"
 	"net/http"
+	"regexp"
 	"strconv"
 	"time"
 
+	"github.com/GolangDeveloperAlmir/order-service/internal/order/domain"
+	ordersvc "github.com/GolangDeveloperAlmir/order-service/internal/order/service"
+	"github.com/GolangDeveloperAlmir/order-service/internal/platform/idempotency"
 	"github.com/GolangDeveloperAlmir/order-service/internal/platform/log"
+	"github.com/GolangDeveloperAlmir/order-service/internal/platform/saga"
+	"github.com/GolangDeveloperAlmir/order-service/pkg/respond"
+	"github.com/google/uuid"
 )
+
+const maxBodyBytes = 1 << 20
+
+var currencyRe = regexp.MustCompile("^[A-Z]{3}$")
 
 type Service interface {
 	Create(ctx context.Context, customerID uuid.UUID, currency string, items []domain.Item) (*domain.Order, error)
@@ -42,9 +47,16 @@ type createReq struct {
 
 func (h *Handler) Create(w http.ResponseWriter, r *http.Request) {
 	var req createReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil {
 		h.log.Error("failed to decode json: %v", log.Err(err))
 		respond.Error(w, http.StatusBadRequest, "invalid json")
+		return
+	}
+	if !currencyRe.MatchString(req.Currency) {
+		respond.Error(w, http.StatusBadRequest, "invalid currency")
 		return
 	}
 	cid, err := uuid.Parse(req.CustomerID)
@@ -118,8 +130,11 @@ func (h *Handler) Get(w http.ResponseWriter, r *http.Request) {
 func (h *Handler) List(w http.ResponseWriter, r *http.Request) {
 	cursor := r.URL.Query().Get("cursor")
 	limit, err := strconv.Atoi(r.URL.Query().Get("limit"))
-	if err != nil {
-		h.log.Error("failed to parse limit: %v", log.Err(err))
+	if err != nil || limit <= 0 {
+		limit = 20
+	}
+	if limit > 100 {
+		limit = 100
 	}
 
 	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
@@ -146,7 +161,10 @@ func (h *Handler) PatchStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req patchStatusReq
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Status == "" {
+	r.Body = http.MaxBytesReader(w, r.Body, maxBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&req); err != nil || req.Status == "" {
 		h.log.Error("failed to decode body: %v", log.Err(err))
 		respond.Error(w, http.StatusBadRequest, "invalid body")
 		return


### PR DESCRIPTION
## Summary
- enforce request body size limits and reject unknown JSON fields
- validate currency codes and sanitize order list limits
- apply same strict decoding to status updates

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b1bb6acd648329acc18cf02ec13853