### PR TITLE
harden order API request handling

### DIFF
--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -1,0 +1,18 @@
+package request
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+const MaxBodyBytes = 1 << 20
+
+func DecodeJSON(w http.ResponseWriter, r *http.Request, dst any) error {
+	r.Body = http.MaxBytesReader(w, r.Body, MaxBodyBytes)
+	dec := json.NewDecoder(r.Body)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- enforce request body size limits and reject unknown JSON fields
- validate currency codes and sanitize order list limits
- apply same strict decoding to status updates
- factor JSON request decoding into shared helper

## Testing
- `go test ./internal/order/domain -run TestNewOrderComputesTotalAndValidates -count=1 -v`
- `go test ./...` *(fails: integration tests hang without external dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b1bb6acd648329acc18cf02ec13853